### PR TITLE
Add client for GET /usage_events/:id

### DIFF
--- a/lib/vault-usage-client/client.rb
+++ b/lib/vault-usage-client/client.rb
@@ -114,6 +114,32 @@ module Vault::Usage
                      expects: [201])
     end
 
+    # Request a single usage event.
+    #
+    # @raise [Excon::Errors::HTTPStatusError] Raised if the server returns an
+    #   unsuccessful HTTP status code.
+    # @return [Array] A single usage event, matching the following format:
+    #
+    #     ```json
+    #       {id: '<event-uuid>',
+    #        product: '<name>',
+    #        consumer: '<heroku-id>',
+    #        start_time: '<YYYY-MM-DDTHH:MM:SSZ>',
+    #        stop_time: '<YYYY-MM-DDTHH:MM:SSZ>',
+    #        detail: {<key1>: <value1>,
+    #                 <key2>: <value2> }
+    #       }
+    #
+    def usage_for_event(event_id)
+      path = "/usage_events/#{event_id}"
+      connection = Excon.new(@url)
+      response = connection.get(path: path, expects: [200])
+      event = MultiJson.load(response.body, {symbolize_keys: true})
+      event.each do |key, value|
+        event[key] = parse_date(value) if date?(value)
+      end
+    end
+
     # Get the usage events for the apps owned by the specified user during the
     # specified period.
     #

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -212,6 +212,30 @@ class ClientTest < Vault::TestCase
     end
   end
 
+  def test_usage_for_event
+    Excon.stub(method: :get) do |request|
+      assert_equal('Basic dXNlcm5hbWU6c2VjcmV0',
+                   request[:headers]['Authorization'])
+      assert_equal('vault-usage.herokuapp.com', request[:host])
+      assert_equal(443, request[:port])
+      assert_equal("/usage_events/#{@event_id}",
+                   request[:path])
+      Excon.stubs.pop
+      {status: 200, body: MultiJson.dump({id: @event_id,
+                                          product: @product_name,
+                                          consumer: @app_hid,
+                                          start_time: iso_format(@start_time),
+                                          stop_time: iso_format(@stop_time),
+                                          detail: {}})}
+    end
+    assert_equal({id: @event_id,
+                  product: @product_name,
+                  consumer: @app_hid,
+                  start_time: @start_time,
+                  stop_time: @stop_time,
+                  detail: {}}, @client.usage_for_event(@event_id))
+  end
+
   # Client.usage_for_user makes a GET request to the Vault::Usage HTTP API,
   # passing the supplied credentials using HTTP basic auth, to retrieve the
   # usage events for a particular user that occurred during the specified


### PR DESCRIPTION
Adds a client for the `GET /usage_events/:id` endpoint.

cc: @Adovenmuehle 